### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/


### PR DESCRIPTION
Alters the gitignore file to prevent the .idea folder produced by IntelliJ from being imported in any pull requests